### PR TITLE
Cache the `.tox` directory on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      rm_tox_dir:
+        description: 'Delete and recreate cached .tox dir'
+        type: boolean
+        required: true
+        default: false
   schedule:
   - cron: '0 1 * * *'
 jobs:
@@ -13,7 +19,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: format-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            format-${{ runner.os }}-tox-
       - run: python -m pip install tox
+      - run: echo ${{ github.head_ref }}
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/checkformatting
       - run: tox -e checkformatting
   Lint:
     runs-on: ubuntu-latest
@@ -23,7 +39,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: lint-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            lint-${{ runner.os }}-tox-
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/lint
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
@@ -37,7 +62,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tests-${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            tests-${{ runner.os }}-${{ matrix.python-version }}-tox-
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/tests
       - run: tox -e tests
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
@@ -53,11 +87,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: coverage-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            coverage-${{ runner.os }}-tox-
       - name: Download coverage files
         uses: actions/download-artifact@v3
         with:
           name: coverage
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/coverage
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
@@ -71,5 +114,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: functests-${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            functests-${{ runner.os }}-${{ matrix.python-version }}-tox-
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/functests
       - run: tox -e functests


### PR DESCRIPTION
This can speed up CI on pull requests significantly as we avoid re-installing all the Python packages.

It also means that new releases of our Python dependencies won't cause CI to break because CI won't be using them: it'll be using its cached versions. So this effectively pins our Python dependencies on CI. Our scheduled nightly CI run bypasses this pinning and updates the cache with the latest versions of all dependencies so that our packages do get tested against new versions of their dependencies.

The cached `.tox` directory will *not* be used under certain circumstances:

* If your PR has changed `tox.ini` (compared to `main`) then tox will automatically recreate the venvs

* If your PR has changed `setup.cfg` (compared to `main`) then our [tox-recreate plugin](https://github.com/hypothesis/tox-recreate) will automatically recreate the venvs

* When CI is run on a schedule (every night at midnight) rather than on a PR an `rm -rf .tox/<ENV>` command is run to delete the venv and therefore force its recreation.

  The recreated venv will have the latest versions of all the packages installed in it and will be cached so that future PRs retrieve the latest versions from the cache. The cache will only be updated if CI passed, GHA won't update the cache if the scheduled nightly run failed due to a problem with a new version of a dependency.

  An alternative implementation of this could be if the branch is `main` (or the default branch), rather than if we're running on a schedule.

* If your PR's branch name ends with `-rm-tox-dir` that will trigger the `rm -rf .tox/<ENV>` command. This allows you to send PRs that won't use the cached `.tox` dirs (for example if fixing a bug with a new version of a dependency). Such PRs will not update the cache for other PRs or for scheduled nightly runs due to how GHA's caching works: workflows running on PR branches see files cached on that branch or on `main` but they don't see files cached on other PR branches (and workflows running on `main` only see files cached on `main`)

* When running CI manually you can check a checkbox to enable the `rm -rf .tox/<ENV>` command. If you do this on a PR branch you won't update the cache for other PRs or scheduled nightly runs. If you do it on `main` you will.