### PR TITLE
Test non-caching PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             format-${{ runner.os }}-tox-
       - run: python -m pip install tox
       - run: echo ${{ github.head_ref }}
-      - if: github.event.schedule || inputs.rm_tox_dir || startsWith(github.head_ref, 'rm-tox-dir')
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
         run: rm -rf .tox/checkformatting
       - run: tox -e checkformatting
   Lint:
@@ -47,7 +47,7 @@ jobs:
           restore-keys: |
             lint-${{ runner.os }}-tox-
       - run: python -m pip install tox
-      - if: github.event.schedule || inputs.rm_tox_dir || startsWith(github.head_ref, 'rm-tox-dir')
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
         run: rm -rf .tox/lint
       - run: tox -e lint
   Tests:
@@ -70,7 +70,7 @@ jobs:
           restore-keys: |
             tests-${{ runner.os }}-${{ matrix.python-version }}-tox-
       - run: python -m pip install tox
-      - if: github.event.schedule || inputs.rm_tox_dir || startsWith(github.head_ref, 'rm-tox-dir')
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
         run: rm -rf .tox/tests
       - run: tox -e tests
       - name: Upload coverage file
@@ -99,7 +99,7 @@ jobs:
         with:
           name: coverage
       - run: python -m pip install tox
-      - if: github.event.schedule || inputs.rm_tox_dir || startsWith(github.head_ref, 'rm-tox-dir')
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
         run: rm -rf .tox/coverage
       - run: tox -e coverage
   Functests:
@@ -122,6 +122,6 @@ jobs:
           restore-keys: |
             functests-${{ runner.os }}-${{ matrix.python-version }}-tox-
       - run: python -m pip install tox
-      - if: github.event.schedule || inputs.rm_tox_dir || startsWith(github.head_ref, 'rm-tox-dir')
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
         run: rm -rf .tox/functests
       - run: tox -e functests


### PR DESCRIPTION
This PR should `rm` the cached `.tox` dirs because its branch name ends with `-rm-tox-dir`