### PR TITLE
Move to `cache-the-tox-dir-for-pypackages`

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -1,6 +1,7 @@
 {
   "template": "https://github.com/hypothesis/cookiecutters",
   "directory": "pypackage",
+  "checkout": "cache-the-tox-dir-for-pypackages",
   "ignore": [],
   "extra_context": {
     "name": "cookiecutter-pypackage-test",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 on:
   push:
   workflow_dispatch:
+    inputs:
+      rm_tox_dir:
+        description: 'Delete and recreate cached .tox dir'
+        type: boolean
+        required: true
+        default: false
   schedule:
   - cron: '0 1 * * *'
 jobs:
@@ -13,7 +19,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: format-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/checkformatting
       - run: tox -e checkformatting
   Lint:
     runs-on: ubuntu-latest
@@ -23,7 +36,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: lint-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/lint
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
@@ -37,7 +57,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tests-${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/tests
       - run: tox -e tests
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
@@ -53,11 +80,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: coverage-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
       - name: Download coverage files
         uses: actions/download-artifact@v3
         with:
           name: coverage
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/coverage
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
@@ -71,5 +105,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache the .tox dir
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: functests-${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
       - run: python -m pip install tox
+      - if: github.event.schedule || inputs.rm_tox_dir || endsWith(github.head_ref, '-rm-tox-dir')
+        run: rm -rf .tox/functests
       - run: tox -e functests

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = tests
 minversion = 3.25.0
 requires =
     tox-envfile
-    tox-faster
+    tox-faster>=0.0.4
     tox-run-command
     tox-recreate
 isolated_build = true


### PR DESCRIPTION
Move this project over to the `cache-the-tox-dir-for-pypackages` branch of the cookiecutter (https://github.com/hypothesis/cookiecutters/pull/34)