### PR TITLE
Add a test workflow for GitHub CLI extensions

### DIFF
--- a/.github/workflows/github_cli_extensions_test.yml
+++ b/.github/workflows/github_cli_extensions_test.yml
@@ -1,0 +1,14 @@
+name: GitHub CLI Extensions Test
+on:
+  workflow_dispatch:
+jobs:
+  GitHub_CLI_Extensions_Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: gh extension install vilmibm/gh-user-status
+      - run: gh user-status get seanh


### PR DESCRIPTION
This is just a quick test of whether GitHub CLI extensions can be installed and used in GitHub Actions workflows.
